### PR TITLE
ensure fast path can only be requested once

### DIFF
--- a/src/main/java/com/github/davidmoten/rtree/OnSubscribeSearch.java
+++ b/src/main/java/com/github/davidmoten/rtree/OnSubscribeSearch.java
@@ -57,6 +57,7 @@ final class OnSubscribeSearch<T> implements OnSubscribe<Entry<T>> {
 		}
 
 		private void requestAll() {
+			requested.set(Long.MAX_VALUE);
 			node.search(condition, subscriber);
 			if (!subscriber.isUnsubscribed())
 				subscriber.onCompleted();


### PR DESCRIPTION
need to set requested to Long.MAX_VALUE to prevent repeated calls of fast path
