### PR TITLE
Restrict access to Point,Rectangle,Circle constructors

### DIFF
--- a/src/main/java/com/github/davidmoten/rtree/RTree.java
+++ b/src/main/java/com/github/davidmoten/rtree/RTree.java
@@ -1,5 +1,6 @@
 package com.github.davidmoten.rtree;
 
+import static com.github.davidmoten.rtree.geometry.Geometries.rectangle;
 import static com.google.common.base.Optional.absent;
 import static com.google.common.base.Optional.of;
 
@@ -9,6 +10,7 @@ import rx.Observable;
 import rx.functions.Func1;
 import rx.functions.Func2;
 
+import com.github.davidmoten.rtree.geometry.Geometries;
 import com.github.davidmoten.rtree.geometry.Geometry;
 import com.github.davidmoten.rtree.geometry.Rectangle;
 import com.github.davidmoten.rx.operators.OperatorBoundedPriorityQueue;
@@ -599,7 +601,7 @@ public final class RTree<R> {
                                 else
                                     return of(entry.geometry().mbr());
                             }
-                        }).toBlocking().single().or(new Rectangle(0, 0, 0, 0));
+                        }).toBlocking().single().or(rectangle(0, 0, 0, 0));
     }
 
     Optional<? extends Node<R>> root() {

--- a/src/main/java/com/github/davidmoten/rtree/geometry/Circle.java
+++ b/src/main/java/com/github/davidmoten/rtree/geometry/Circle.java
@@ -9,7 +9,7 @@ public final class Circle implements Geometry {
     private final float x, y, radius;
     private final Rectangle mbr;
 
-    public Circle(float x, float y, float radius) {
+    protected Circle(float x, float y, float radius) {
         this.x = x;
         this.y = y;
         this.radius = radius;

--- a/src/main/java/com/github/davidmoten/rtree/geometry/Geometries.java
+++ b/src/main/java/com/github/davidmoten/rtree/geometry/Geometries.java
@@ -21,5 +21,5 @@ public final class Geometries {
     public static Circle circle(double x, double y, double radius) {
         return Circle.create(x, y, radius);
     }
-
+    
 }

--- a/src/main/java/com/github/davidmoten/rtree/geometry/Point.java
+++ b/src/main/java/com/github/davidmoten/rtree/geometry/Point.java
@@ -8,7 +8,7 @@ public final class Point implements Geometry {
 
     private final Rectangle mbr;
 
-    public Point(float x, float y) {
+    protected Point(float x, float y) {
         this.mbr = Rectangle.create(x, y, x, y);
     }
 

--- a/src/main/java/com/github/davidmoten/rtree/geometry/Rectangle.java
+++ b/src/main/java/com/github/davidmoten/rtree/geometry/Rectangle.java
@@ -8,7 +8,7 @@ import com.google.common.base.Preconditions;
 public final class Rectangle implements Geometry, HasGeometry {
     private final float x1, y1, x2, y2;
 
-    public Rectangle(float x1, float y1, float x2, float y2) {
+    protected Rectangle(float x1, float y1, float x2, float y2) {
         Preconditions.checkArgument(x2 >= x1);
         Preconditions.checkArgument(y2 >= y1);
         this.x1 = x1;


### PR DESCRIPTION
make constructors of Point,Rectangle,Circle protected to force use of Geometries static factory methods. This might make later refactorings have less impact (for example make Circle and interface).
