### PR TITLE
strong typing of RTree entry geometry

### DIFF
--- a/src/main/java/com/github/davidmoten/rtree/Comparators.java
+++ b/src/main/java/com/github/davidmoten/rtree/Comparators.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import rx.functions.Func1;
 
+import com.github.davidmoten.rtree.geometry.Geometry;
 import com.github.davidmoten.rtree.geometry.HasGeometry;
 import com.github.davidmoten.rtree.geometry.ListPair;
 import com.github.davidmoten.rtree.geometry.Rectangle;
@@ -38,7 +39,7 @@ public final class Comparators {
      * total of the areas of overlap of the members of the list with the
      * rectangle r.
      * 
-     * @param <T> 
+     * @param <T>
      *            type of geometry being compared
      * @param r
      *            rectangle
@@ -107,10 +108,11 @@ public final class Comparators {
      *            the entry type
      * @return a comparator to sort by ascending distance from the rectangle
      */
-    public static <S> Comparator<Entry<S>> ascendingDistance(final Rectangle r) {
-        return new Comparator<Entry<S>>() {
+    public static <T, S extends Geometry> Comparator<Entry<T, S>> ascendingDistance(
+            final Rectangle r) {
+        return new Comparator<Entry<T, S>>() {
             @Override
-            public int compare(Entry<S> e1, Entry<S> e2) {
+            public int compare(Entry<T, S> e1, Entry<T, S> e2) {
                 return ((Double) e1.geometry().distance(r)).compareTo(e2.geometry().distance(r));
             }
         };

--- a/src/main/java/com/github/davidmoten/rtree/Entry.java
+++ b/src/main/java/com/github/davidmoten/rtree/Entry.java
@@ -13,9 +13,9 @@ import com.google.common.base.Preconditions;
  * @param <T>
  *            the type of Entry
  */
-public final class Entry<T> implements HasGeometry {
+public final class Entry<T, S extends Geometry> implements HasGeometry {
     private final T value;
-    private final Geometry geometry;
+    private final S geometry;
 
     /**
      * Constructor.
@@ -25,7 +25,7 @@ public final class Entry<T> implements HasGeometry {
      * @param geometry
      *            the geometry of the value
      */
-    public Entry(T value, Geometry geometry) {
+    public Entry(T value, S geometry) {
         Preconditions.checkNotNull(geometry);
         this.value = value;
         this.geometry = geometry;
@@ -34,13 +34,16 @@ public final class Entry<T> implements HasGeometry {
     /**
      * Factory method.
      * 
-     * @param <T> type of value
-     * @param value object being given a spatial context
-     * @param geometry geometry associated with the value
+     * @param <T>
+     *            type of value
+     * @param value
+     *            object being given a spatial context
+     * @param geometry
+     *            geometry associated with the value
      * @return entry wrapping value and associated geometry
      */
-    public static <T> Entry<T> entry(T value, Geometry geometry) {
-        return new Entry<T>(value, geometry);
+    public static <T, S extends Geometry> Entry<T, S> entry(T value, S geometry) {
+        return new Entry<T, S>(value, geometry);
     }
 
     /**
@@ -53,7 +56,7 @@ public final class Entry<T> implements HasGeometry {
     }
 
     @Override
-    public Geometry geometry() {
+    public S geometry() {
         return geometry;
     }
 

--- a/src/main/java/com/github/davidmoten/rtree/Node.java
+++ b/src/main/java/com/github/davidmoten/rtree/Node.java
@@ -8,13 +8,14 @@ import rx.functions.Func1;
 import com.github.davidmoten.rtree.geometry.Geometry;
 import com.github.davidmoten.rtree.geometry.HasGeometry;
 
-interface Node<T> extends HasGeometry {
+interface Node<T, S extends Geometry> extends HasGeometry {
 
-    List<Node<T>> add(Entry<T> entry);
+    List<Node<T, S>> add(Entry<? extends T, ? extends S> entry);
 
-    NodeAndEntries<T> delete(Entry<T> entry, boolean all);
+    NodeAndEntries<T, S> delete(Entry<? extends T, ? extends S> entry, boolean all);
 
-    void search(Func1<? super Geometry, Boolean> condition, Subscriber<? super Entry<T>> subscriber);
+    void search(Func1<? super Geometry, Boolean> condition,
+            Subscriber<? super Entry<T, S>> subscriber);
 
     int count();
 

--- a/src/main/java/com/github/davidmoten/rtree/NodeAndEntries.java
+++ b/src/main/java/com/github/davidmoten/rtree/NodeAndEntries.java
@@ -2,6 +2,7 @@ package com.github.davidmoten.rtree;
 
 import java.util.List;
 
+import com.github.davidmoten.rtree.geometry.Geometry;
 import com.google.common.base.Optional;
 
 /**
@@ -10,10 +11,10 @@ import com.google.common.base.Optional;
  * @param <T>
  *            entry type
  */
-class NodeAndEntries<T> {
+class NodeAndEntries<T, S extends Geometry> {
 
-    private final Optional<? extends Node<T>> node;
-    private final List<Entry<T>> entries;
+    private final Optional<? extends Node<T, S>> node;
+    private final List<Entry<T, S>> entries;
     private final int count;
 
     /**
@@ -29,17 +30,18 @@ class NodeAndEntries<T> {
      * @param countDeleted
      *            count of the number of entries removed
      */
-    public NodeAndEntries(Optional<? extends Node<T>> node, List<Entry<T>> entries, int countDeleted) {
+    public NodeAndEntries(Optional<? extends Node<T, S>> node, List<Entry<T, S>> entries,
+            int countDeleted) {
         this.node = node;
         this.entries = entries;
         this.count = countDeleted;
     }
 
-    public Optional<? extends Node<T>> node() {
+    public Optional<? extends Node<T, S>> node() {
         return node;
     }
 
-    public List<Entry<T>> entriesToAdd() {
+    public List<Entry<T, S>> entriesToAdd() {
         return entries;
     }
 

--- a/src/main/java/com/github/davidmoten/rtree/NodePosition.java
+++ b/src/main/java/com/github/davidmoten/rtree/NodePosition.java
@@ -1,16 +1,18 @@
 package com.github.davidmoten.rtree;
 
-final class NodePosition<T> {
+import com.github.davidmoten.rtree.geometry.Geometry;
 
-    private final Node<T> node;
+final class NodePosition<T, S extends Geometry> {
+
+    private final Node<T, S> node;
     private final int position;
 
-    NodePosition(Node<T> node, int position) {
+    NodePosition(Node<T, S> node, int position) {
         this.node = node;
         this.position = position;
     }
 
-    Node<T> node() {
+    Node<T, S> node() {
         return node;
     }
 
@@ -18,8 +20,8 @@ final class NodePosition<T> {
         return position;
     }
 
-    NodePosition<T> nextPosition() {
-        return new NodePosition<T>(node, position + 1);
+    NodePosition<T, S> nextPosition() {
+        return new NodePosition<T, S>(node, position + 1);
     }
 
 }

--- a/src/main/java/com/github/davidmoten/rtree/NonLeaf.java
+++ b/src/main/java/com/github/davidmoten/rtree/NonLeaf.java
@@ -15,13 +15,13 @@ import com.github.davidmoten.rtree.geometry.Rectangle;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 
-final class NonLeaf<T> implements Node<T> {
+final class NonLeaf<T, S extends Geometry> implements Node<T, S> {
 
-    private final List<? extends Node<T>> children;
+    private final List<? extends Node<T, S>> children;
     private final Rectangle mbr;
     private final Context context;
 
-    NonLeaf(List<? extends Node<T>> children, Context context) {
+    NonLeaf(List<? extends Node<T, S>> children, Context context) {
         Preconditions.checkArgument(!children.isEmpty());
         this.context = context;
         this.children = children;
@@ -35,15 +35,15 @@ final class NonLeaf<T> implements Node<T> {
 
     @Override
     public void search(Func1<? super Geometry, Boolean> criterion,
-            Subscriber<? super Entry<T>> subscriber) {
+            Subscriber<? super Entry<T, S>> subscriber) {
 
         if (!criterion.call(this.geometry().mbr()))
             return;
 
-        for (final Node<T> child : children) {
+        for (final Node<T, S> child : children) {
             if (subscriber.isUnsubscribed())
                 return;
-            else 
+            else
                 child.search(criterion, subscriber);
         }
     }
@@ -53,33 +53,33 @@ final class NonLeaf<T> implements Node<T> {
         return children.size();
     }
 
-    public List<? extends Node<T>> children() {
+    public List<? extends Node<T, S>> children() {
         return children;
     }
 
     @Override
-    public List<Node<T>> add(Entry<T> entry) {
-        final Node<T> child = context.selector().select(entry.geometry().mbr(), children);
-        List<Node<T>> list = child.add(entry);
-        List<? extends Node<T>> children2 = Util.replace(children, child, list);
+    public List<Node<T, S>> add(Entry<? extends T, ? extends S> entry) {
+        final Node<T, S> child = context.selector().select(entry.geometry().mbr(), children);
+        List<Node<T, S>> list = child.add(entry);
+        List<? extends Node<T, S>> children2 = Util.replace(children, child, list);
         if (children2.size() <= context.maxChildren())
-            return Collections.singletonList((Node<T>) new NonLeaf<T>(children2, context));
+            return Collections.singletonList((Node<T, S>) new NonLeaf<T, S>(children2, context));
         else {
-            ListPair<? extends Node<T>> pair = context.splitter().split(children2,
+            ListPair<? extends Node<T, S>> pair = context.splitter().split(children2,
                     context.minChildren());
             return makeNonLeaves(pair);
         }
     }
 
-    private List<Node<T>> makeNonLeaves(ListPair<? extends Node<T>> pair) {
-        List<Node<T>> list = new ArrayList<Node<T>>();
-        list.add(new NonLeaf<T>(pair.group1().list(), context));
-        list.add(new NonLeaf<T>(pair.group2().list(), context));
+    private List<Node<T, S>> makeNonLeaves(ListPair<? extends Node<T, S>> pair) {
+        List<Node<T, S>> list = new ArrayList<Node<T, S>>();
+        list.add(new NonLeaf<T, S>(pair.group1().list(), context));
+        list.add(new NonLeaf<T, S>(pair.group2().list(), context));
         return list;
     }
 
     @Override
-    public NodeAndEntries<T> delete(Entry<T> entry, boolean all) {
+    public NodeAndEntries<T, S> delete(Entry<? extends T, ? extends S> entry, boolean all) {
         // the result of performing a delete of the given entry from this node
         // will be that zero or more entries will be needed to be added back to
         // the root of the tree (because num entries of their node fell below
@@ -88,14 +88,14 @@ final class NonLeaf<T> implements Node<T> {
         // zero or more nodes to be added as children to this node(because
         // entries have been deleted from them and they still have enough
         // members to be active)
-        List<Entry<T>> addTheseEntries = new ArrayList<Entry<T>>();
-        List<Node<T>> removeTheseNodes = new ArrayList<Node<T>>();
-        List<Node<T>> addTheseNodes = new ArrayList<Node<T>>();
+        List<Entry<T, S>> addTheseEntries = new ArrayList<Entry<T, S>>();
+        List<Node<T, S>> removeTheseNodes = new ArrayList<Node<T, S>>();
+        List<Node<T, S>> addTheseNodes = new ArrayList<Node<T, S>>();
         int countDeleted = 0;
 
-        for (final Node<T> child : children) {
+        for (final Node<T, S> child : children) {
             if (entry.geometry().intersects(child.geometry().mbr())) {
-                final NodeAndEntries<T> result = child.delete(entry, all);
+                final NodeAndEntries<T, S> result = child.delete(entry, all);
                 if (result.node().isPresent()) {
                     if (result.node().get() != child) {
                         // deletion occurred and child is above minChildren so
@@ -120,16 +120,16 @@ final class NonLeaf<T> implements Node<T> {
             }
         }
         if (removeTheseNodes.isEmpty())
-            return new NodeAndEntries<T>(of(this), Collections.<Entry<T>> emptyList(), 0);
+            return new NodeAndEntries<T, S>(of(this), Collections.<Entry<T, S>> emptyList(), 0);
         else {
-            List<Node<T>> nodes = Util.remove(children, removeTheseNodes);
+            List<Node<T, S>> nodes = Util.remove(children, removeTheseNodes);
             nodes.addAll(addTheseNodes);
             if (nodes.size() == 0)
-                return new NodeAndEntries<T>(Optional.<Node<T>> absent(), addTheseEntries,
+                return new NodeAndEntries<T, S>(Optional.<Node<T, S>> absent(), addTheseEntries,
                         countDeleted);
             else {
-                NonLeaf<T> node = new NonLeaf<T>(nodes, context);
-                return new NodeAndEntries<T>(of(node), addTheseEntries, countDeleted);
+                NonLeaf<T, S> node = new NonLeaf<T, S>(nodes, context);
+                return new NodeAndEntries<T, S>(of(node), addTheseEntries, countDeleted);
             }
         }
     }

--- a/src/main/java/com/github/davidmoten/rtree/OnSubscribeSearch.java
+++ b/src/main/java/com/github/davidmoten/rtree/OnSubscribeSearch.java
@@ -10,35 +10,35 @@ import rx.functions.Func1;
 import com.github.davidmoten.rtree.geometry.Geometry;
 import com.github.davidmoten.util.ImmutableStack;
 
-final class OnSubscribeSearch<T> implements OnSubscribe<Entry<T>> {
+final class OnSubscribeSearch<T, S extends Geometry> implements OnSubscribe<Entry<T, S>> {
 
-    private final Node<T> node;
+    private final Node<T, S> node;
     private final Func1<? super Geometry, Boolean> condition;
 
-    OnSubscribeSearch(Node<T> node, Func1<? super Geometry, Boolean> condition) {
+    OnSubscribeSearch(Node<T, S> node, Func1<? super Geometry, Boolean> condition) {
         this.node = node;
         this.condition = condition;
     }
 
     @Override
-    public void call(Subscriber<? super Entry<T>> subscriber) {
-        subscriber.setProducer(new SearchProducer<T>(node, condition, subscriber));
+    public void call(Subscriber<? super Entry<T, S>> subscriber) {
+        subscriber.setProducer(new SearchProducer<T, S>(node, condition, subscriber));
     }
 
-    private static class SearchProducer<T> implements Producer {
+    private static class SearchProducer<T, S extends Geometry> implements Producer {
 
-        private final Subscriber<? super Entry<T>> subscriber;
-        private final Node<T> node;
+        private final Subscriber<? super Entry<T, S>> subscriber;
+        private final Node<T, S> node;
         private final Func1<? super Geometry, Boolean> condition;
-        private volatile ImmutableStack<NodePosition<T>> stack;
+        private volatile ImmutableStack<NodePosition<T, S>> stack;
         private final AtomicLong requested = new AtomicLong(0);
 
-        SearchProducer(Node<T> node, Func1<? super Geometry, Boolean> condition,
-                Subscriber<? super Entry<T>> subscriber) {
+        SearchProducer(Node<T, S> node, Func1<? super Geometry, Boolean> condition,
+                Subscriber<? super Entry<T, S>> subscriber) {
             this.node = node;
             this.condition = condition;
             this.subscriber = subscriber;
-            stack = ImmutableStack.create(new NodePosition<T>(node, 0));
+            stack = ImmutableStack.create(new NodePosition<T, S>(node, 0));
         }
 
         @Override

--- a/src/main/java/com/github/davidmoten/rtree/Selector.java
+++ b/src/main/java/com/github/davidmoten/rtree/Selector.java
@@ -15,7 +15,8 @@ public interface Selector {
      * Returns the node from a list of nodes that an object with the given
      * geometry would be added to.
      * 
-     * @param <T> type of value of entry in tree
+     * @param <T>
+     *            type of value of entry in tree
      * @param g
      *            geometry
      * @param nodes
@@ -24,6 +25,6 @@ public interface Selector {
      * @throws NoSuchElementException
      *             if nodes is empty
      */
-    <T> Node<T> select(Geometry g, List<? extends Node<T>> nodes);
+    <T, S extends Geometry> Node<T, S> select(Geometry g, List<? extends Node<T, S>> nodes);
 
 }

--- a/src/main/java/com/github/davidmoten/rtree/SelectorMinimalAreaIncrease.java
+++ b/src/main/java/com/github/davidmoten/rtree/SelectorMinimalAreaIncrease.java
@@ -17,7 +17,7 @@ public final class SelectorMinimalAreaIncrease implements Selector {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> Node<T> select(Geometry g, List<? extends Node<T>> nodes) {
+    public <T, S extends Geometry> Node<T, S> select(Geometry g, List<? extends Node<T, S>> nodes) {
         return min(nodes, compose(areaIncreaseComparator(g.mbr()), areaComparator(g.mbr())));
     }
 }

--- a/src/main/java/com/github/davidmoten/rtree/SelectorMinimalOverlapArea.java
+++ b/src/main/java/com/github/davidmoten/rtree/SelectorMinimalOverlapArea.java
@@ -14,7 +14,7 @@ public class SelectorMinimalOverlapArea implements Selector {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> Node<T> select(Geometry g, List<? extends Node<T>> nodes) {
+    public <T, S extends Geometry> Node<T, S> select(Geometry g, List<? extends Node<T, S>> nodes) {
         return min(
                 nodes,
                 compose(overlapAreaComparator(g.mbr(), nodes), areaIncreaseComparator(g.mbr()),

--- a/src/main/java/com/github/davidmoten/rtree/SelectorRStar.java
+++ b/src/main/java/com/github/davidmoten/rtree/SelectorRStar.java
@@ -14,7 +14,7 @@ public class SelectorRStar implements Selector {
     private static Selector areaIncreaseSelector = new SelectorMinimalAreaIncrease();
 
     @Override
-    public <T> Node<T> select(Geometry g, List<? extends Node<T>> nodes) {
+    public <T, S extends Geometry> Node<T, S> select(Geometry g, List<? extends Node<T, S>> nodes) {
         boolean leafNodes = nodes.get(0) instanceof Leaf;
         if (leafNodes)
             return overlapAreaSelector.select(g, nodes);

--- a/src/main/java/com/github/davidmoten/rtree/Util.java
+++ b/src/main/java/com/github/davidmoten/rtree/Util.java
@@ -35,7 +35,8 @@ public final class Util {
      * c.g.d.r.BenchmarksMbr.mbrOldList4    thrpt       10  14891862.638   198765.157  ops/s
      * </pre>
      * 
-     * @param items items to bound
+     * @param items
+     *            items to bound
      * @return the minimum bounding rectangle containings items
      */
     public static Rectangle mbr(Collection<? extends HasGeometry> items) {

--- a/src/main/java/com/github/davidmoten/rtree/geometry/Geometry.java
+++ b/src/main/java/com/github/davidmoten/rtree/geometry/Geometry.java
@@ -33,18 +33,11 @@ public interface Geometry {
     double distance(Rectangle r);
 
     /**
-     * Returns true if and only if the geometry intersects the given rectangle.
-     * Ensure is consistent with distance(Rectangle).
-     * 
-     * @param r rectangle to test intersection with
-     * @return true if and only if this and r intersect
-     */
-    boolean intersects(Rectangle r);
-
-    /**
      * Returns the minimum bounding rectangle of this geometry.
      * 
      * @return minimum bounding rectangle
      */
     Rectangle mbr();
+
+    boolean intersects(Rectangle r);
 }

--- a/src/test/java/com/github/davidmoten/rtree/BackpressureTest.java
+++ b/src/test/java/com/github/davidmoten/rtree/BackpressureTest.java
@@ -31,7 +31,7 @@ public class BackpressureTest {
     @Test
     public void testBackpressureSearch() {
         Subscriber<Object> sub = Mockito.mock(Subscriber.class);
-        ImmutableStack<NodePosition<Object>> stack = ImmutableStack.empty();
+        ImmutableStack<NodePosition<Object, Geometry>> stack = ImmutableStack.empty();
         Func1<Geometry, Boolean> condition = Mockito.mock(Func1.class);
         Backpressure.search(condition, sub, stack, 1);
         Mockito.verify(sub, Mockito.never()).onNext(Mockito.any());
@@ -68,12 +68,13 @@ public class BackpressureTest {
                 return !subscribed;
             }
         });
-        Node<Object> node = Mockito.mock(Node.class);
-        NodePosition<Object> np = new NodePosition<Object>(node, 1);
-        ImmutableStack<NodePosition<Object>> stack = ImmutableStack.<NodePosition<Object>> empty()
-                .push(np);
+        Node<Object, Geometry> node = Mockito.mock(Node.class);
+        NodePosition<Object, Geometry> np = new NodePosition<Object, Geometry>(node, 1);
+        ImmutableStack<NodePosition<Object, Geometry>> stack = ImmutableStack
+                .<NodePosition<Object, Geometry>> empty().push(np);
         Func1<Geometry, Boolean> condition = Mockito.mock(Func1.class);
-        ImmutableStack<NodePosition<Object>> stack2 = Backpressure.search(condition, sub, stack, 0);
+        ImmutableStack<NodePosition<Object, Geometry>> stack2 = Backpressure.search(condition, sub,
+                stack, 0);
         assertTrue(stack2 == stack);
     }
 
@@ -110,24 +111,25 @@ public class BackpressureTest {
             }
         });
         sub.unsubscribe();
-        Node<Object> node = Mockito.mock(Node.class);
-        NodePosition<Object> np = new NodePosition<Object>(node, 1);
-        ImmutableStack<NodePosition<Object>> stack = ImmutableStack.<NodePosition<Object>> empty()
-                .push(np);
+        Node<Object, Geometry> node = Mockito.mock(Node.class);
+        NodePosition<Object, Geometry> np = new NodePosition<Object, Geometry>(node, 1);
+        ImmutableStack<NodePosition<Object, Geometry>> stack = ImmutableStack
+                .<NodePosition<Object, Geometry>> empty().push(np);
         Func1<Geometry, Boolean> condition = Mockito.mock(Func1.class);
-        ImmutableStack<NodePosition<Object>> stack2 = Backpressure.search(condition, sub, stack, 1);
+        ImmutableStack<NodePosition<Object, Geometry>> stack2 = Backpressure.search(condition, sub,
+                stack, 1);
         assertTrue(stack2.isEmpty());
     }
 
     @Test
     public void testBackpressureIterateWhenNodeHasMaxChildrenAndIsRoot() {
-        Entry<Object> e1 = RTreeTest.e(1);
+        Entry<Object, Geometry> e1 = RTreeTest.e(1);
         @SuppressWarnings("unchecked")
-        List<Entry<Object>> list = Arrays.asList(e1, e1, e1, e1);
-        RTree<Object> tree = RTree.star().maxChildren(4).create().add(list);
-        HashSet<Entry<Object>> expected = new HashSet<Entry<Object>>(list);
-        final HashSet<Entry<Object>> found = new HashSet<Entry<Object>>();
-        tree.entries().subscribe(new Subscriber<Entry<Object>>() {
+        List<Entry<Object, Geometry>> list = Arrays.asList(e1, e1, e1, e1);
+        RTree<Object, Geometry> tree = RTree.star().maxChildren(4).create().add(list);
+        HashSet<Entry<Object, Geometry>> expected = new HashSet<Entry<Object, Geometry>>(list);
+        final HashSet<Entry<Object, Geometry>> found = new HashSet<Entry<Object, Geometry>>();
+        tree.entries().subscribe(new Subscriber<Entry<Object, Geometry>>() {
 
             @Override
             public void onStart() {
@@ -145,23 +147,23 @@ public class BackpressureTest {
             }
 
             @Override
-            public void onNext(Entry<Object> t) {
+            public void onNext(Entry<Object, Geometry> t) {
                 found.add(t);
                 request(1);
             }
         });
         assertEquals(expected, found);
     }
-    
+
     @Test
     public void testBackpressureRequestZero() {
-        Entry<Object> e1 = RTreeTest.e(1);
+        Entry<Object, Geometry> e1 = RTreeTest.e(1);
         @SuppressWarnings("unchecked")
-        List<Entry<Object>> list = Arrays.asList(e1, e1, e1, e1);
-        RTree<Object> tree = RTree.star().maxChildren(4).create().add(list);
-        HashSet<Entry<Object>> expected = new HashSet<Entry<Object>>(list);
-        final HashSet<Entry<Object>> found = new HashSet<Entry<Object>>();
-        tree.entries().subscribe(new Subscriber<Entry<Object>>() {
+        List<Entry<Object, Geometry>> list = Arrays.asList(e1, e1, e1, e1);
+        RTree<Object, Geometry> tree = RTree.star().maxChildren(4).create().add(list);
+        HashSet<Entry<Object, Geometry>> expected = new HashSet<Entry<Object, Geometry>>(list);
+        final HashSet<Entry<Object, Geometry>> found = new HashSet<Entry<Object, Geometry>>();
+        tree.entries().subscribe(new Subscriber<Entry<Object, Geometry>>() {
 
             @Override
             public void onStart() {
@@ -179,7 +181,7 @@ public class BackpressureTest {
             }
 
             @Override
-            public void onNext(Entry<Object> t) {
+            public void onNext(Entry<Object, Geometry> t) {
                 found.add(t);
                 request(0);
             }
@@ -189,14 +191,14 @@ public class BackpressureTest {
 
     @Test
     public void testBackpressureIterateWhenNodeHasMaxChildrenAndIsNotRoot() {
-        Entry<Object> e1 = RTreeTest.e(1);
-        List<Entry<Object>> list = new ArrayList<Entry<Object>>();
+        Entry<Object, Geometry> e1 = RTreeTest.e(1);
+        List<Entry<Object, Geometry>> list = new ArrayList<Entry<Object, Geometry>>();
         for (int i = 1; i <= 17; i++)
             list.add(e1);
-        RTree<Object> tree = RTree.star().maxChildren(4).create().add(list);
-        HashSet<Entry<Object>> expected = new HashSet<Entry<Object>>(list);
-        final HashSet<Entry<Object>> found = new HashSet<Entry<Object>>();
-        tree.entries().subscribe(new Subscriber<Entry<Object>>() {
+        RTree<Object, Geometry> tree = RTree.star().maxChildren(4).create().add(list);
+        HashSet<Entry<Object, Geometry>> expected = new HashSet<Entry<Object, Geometry>>(list);
+        final HashSet<Entry<Object, Geometry>> found = new HashSet<Entry<Object, Geometry>>();
+        tree.entries().subscribe(new Subscriber<Entry<Object, Geometry>>() {
 
             @Override
             public void onStart() {
@@ -214,7 +216,7 @@ public class BackpressureTest {
             }
 
             @Override
-            public void onNext(Entry<Object> t) {
+            public void onNext(Entry<Object, Geometry> t) {
                 found.add(t);
                 request(1);
             }
@@ -224,15 +226,15 @@ public class BackpressureTest {
 
     @Test
     public void testBackpressureIterateWhenConditionFailsAgainstNonLeafNode() {
-        Entry<Object> e1 = e(1);
-        List<Entry<Object>> list = new ArrayList<Entry<Object>>();
+        Entry<Object, Geometry> e1 = e(1);
+        List<Entry<Object, Geometry>> list = new ArrayList<Entry<Object, Geometry>>();
         for (int i = 1; i <= 17; i++)
             list.add(e1);
         list.add(e(2));
-        RTree<Object> tree = RTree.star().maxChildren(4).create().add(list);
-        HashSet<Entry<Object>> expected = new HashSet<Entry<Object>>(list);
-        final HashSet<Entry<Object>> found = new HashSet<Entry<Object>>();
-        tree.entries().subscribe(new Subscriber<Entry<Object>>() {
+        RTree<Object, Geometry> tree = RTree.star().maxChildren(4).create().add(list);
+        HashSet<Entry<Object, Geometry>> expected = new HashSet<Entry<Object, Geometry>>(list);
+        final HashSet<Entry<Object, Geometry>> found = new HashSet<Entry<Object, Geometry>>();
+        tree.entries().subscribe(new Subscriber<Entry<Object, Geometry>>() {
 
             @Override
             public void onStart() {
@@ -250,7 +252,7 @@ public class BackpressureTest {
             }
 
             @Override
-            public void onNext(Entry<Object> t) {
+            public void onNext(Entry<Object, Geometry> t) {
                 found.add(t);
                 request(1);
             }

--- a/src/test/java/com/github/davidmoten/rtree/BenchmarksRTree.java
+++ b/src/test/java/com/github/davidmoten/rtree/BenchmarksRTree.java
@@ -11,50 +11,67 @@ import org.openjdk.jmh.annotations.State;
 import rx.Subscriber;
 
 import com.github.davidmoten.rtree.geometry.Geometries;
+import com.github.davidmoten.rtree.geometry.Point;
+import com.github.davidmoten.rtree.geometry.Rectangle;
 
 @State(Scope.Benchmark)
 public class BenchmarksRTree {
 
-    private final List<Entry<Object>> entries = GreekEarthquakes.entriesList();
+    private final List<Entry<Object, Point>> entries = GreekEarthquakes.entriesList();
 
-    private final List<Entry<Object>> some = entries1000();
+    private final List<Entry<Object, Rectangle>> some = entries1000();
 
-    private final RTree<Object> defaultTreeM4 = RTree.maxChildren(4).create().add(entries);
+    private final RTree<Object, Point> defaultTreeM4 = RTree.maxChildren(4)
+            .<Object, Point> create().add(entries);
 
-    private final RTree<Object> defaultTreeM10 = RTree.maxChildren(10).create().add(entries);
+    private final RTree<Object, Point> defaultTreeM10 = RTree.maxChildren(10)
+            .<Object, Point> create().add(entries);
 
-    private final RTree<Object> starTreeM4 = RTree.maxChildren(4).star().create().add(entries);
+    private final RTree<Object, Point> starTreeM4 = RTree.maxChildren(4).star()
+            .<Object, Point> create().add(entries);
 
-    private final RTree<Object> starTreeM10 = RTree.maxChildren(10).star().create().add(entries);
+    private final RTree<Object, Point> starTreeM10 = RTree.maxChildren(10).star()
+            .<Object, Point> create().add(entries);
 
-    private final RTree<Object> defaultTreeM32 = RTree.maxChildren(32).create().add(entries);
+    private final RTree<Object, Point> defaultTreeM32 = RTree.maxChildren(32)
+            .<Object, Point> create().add(entries);
 
-    private final RTree<Object> starTreeM32 = RTree.maxChildren(32).star().create().add(entries);
+    private final RTree<Object, Point> starTreeM32 = RTree.maxChildren(32).star()
+            .<Object, Point> create().add(entries);
 
-    private final RTree<Object> defaultTreeM128 = RTree.maxChildren(128).create().add(entries);
+    private final RTree<Object, Point> defaultTreeM128 = RTree.maxChildren(128)
+            .<Object, Point> create().add(entries);
 
-    private final RTree<Object> starTreeM128 = RTree.maxChildren(128).star().create().add(entries);
+    private final RTree<Object, Point> starTreeM128 = RTree.maxChildren(128).star()
+            .<Object, Point> create().add(entries);
 
-    private final RTree<Object> smallDefaultTreeM4 = RTree.maxChildren(4).create().add(some);
+    private final RTree<Object, Rectangle> smallDefaultTreeM4 = RTree.maxChildren(4)
+            .<Object, Rectangle> create().add(some);
 
-    private final RTree<Object> smallDefaultTreeM10 = RTree.maxChildren(10).create().add(some);
+    private final RTree<Object, Rectangle> smallDefaultTreeM10 = RTree.maxChildren(10)
+            .<Object, Rectangle> create().add(some);
 
-    private final RTree<Object> smallStarTreeM4 = RTree.maxChildren(4).star().create().add(some);
+    private final RTree<Object, Rectangle> smallStarTreeM4 = RTree.maxChildren(4).star()
+            .<Object, Rectangle> create().add(some);
 
-    private final RTree<Object> smallStarTreeM10 = RTree.maxChildren(10).star().create().add(some);
+    private final RTree<Object, Rectangle> smallStarTreeM10 = RTree.maxChildren(10).star()
+            .<Object, Rectangle> create().add(some);
 
-    private final RTree<Object> smallDefaultTreeM32 = RTree.maxChildren(32).create().add(some);
+    private final RTree<Object, Rectangle> smallDefaultTreeM32 = RTree.maxChildren(32)
+            .<Object, Rectangle> create().add(some);
 
-    private final RTree<Object> smallStarTreeM32 = RTree.maxChildren(32).star().create().add(some);
+    private final RTree<Object, Rectangle> smallStarTreeM32 = RTree.maxChildren(32).star()
+            .<Object, Rectangle> create().add(some);
 
-    private final RTree<Object> smallDefaultTreeM128 = RTree.maxChildren(128).create().add(some);
+    private final RTree<Object, Rectangle> smallDefaultTreeM128 = RTree.maxChildren(128)
+            .<Object, Rectangle> create().add(some);
 
-    private final RTree<Object> smallStarTreeM128 = RTree.maxChildren(128).star().create()
-            .add(some);
+    private final RTree<Object, Rectangle> smallStarTreeM128 = RTree.maxChildren(128).star()
+            .<Object, Rectangle> create().add(some);
 
     @Benchmark
     public void defaultRTreeInsertOneEntryIntoGreekDataEntriesMaxChildren004() {
-        insert(defaultTreeM4);
+        insertPoint(defaultTreeM4);
     }
 
     @Benchmark
@@ -64,7 +81,7 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void defaultRTreeInsertOneEntryIntoGreekDataEntriesMaxChildren010() {
-        insert(defaultTreeM10);
+        insertPoint(defaultTreeM10);
     }
 
     @Benchmark
@@ -74,12 +91,12 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void rStarTreeInsertOneEntryIntoGreekDataEntriesMaxChildren004() {
-        insert(starTreeM4);
+        insertPoint(starTreeM4);
     }
 
     @Benchmark
     public void rStarTreeInsertOneEntryIntoGreekDataEntriesMaxChildren010() {
-        insert(starTreeM10);
+        insertPoint(starTreeM10);
     }
 
     @Benchmark
@@ -99,7 +116,7 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void defaultRTreeInsertOneEntryIntoGreekDataEntriesMaxChildren032() {
-        insert(defaultTreeM32);
+        insertPoint(defaultTreeM32);
     }
 
     @Benchmark
@@ -109,7 +126,7 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void rStarTreeInsertOneEntryIntoGreekDataEntriesMaxChildren032() {
-        insert(starTreeM32);
+        insertPoint(starTreeM32);
     }
 
     @Benchmark
@@ -119,7 +136,7 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void defaultRTreeInsertOneEntryIntoGreekDataEntriesMaxChildren128() {
-        insert(defaultTreeM128);
+        insertPoint(defaultTreeM128);
     }
 
     @Benchmark
@@ -129,7 +146,7 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void rStarTreeInsertOneEntryIntoGreekDataEntriesMaxChildren128() {
-        insert(starTreeM128);
+        insertPoint(starTreeM128);
     }
 
     @Benchmark
@@ -139,7 +156,7 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void defaultRTreeInsertOneEntryInto1000EntriesMaxChildren004() {
-        insert(smallDefaultTreeM4);
+        insertRectangle(smallDefaultTreeM4);
     }
 
     @Benchmark
@@ -149,7 +166,7 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void defaultRTreeInsertOneEntryInto1000EntriesMaxChildren010() {
-        insert(smallDefaultTreeM10);
+        insertRectangle(smallDefaultTreeM10);
     }
 
     @Benchmark
@@ -159,12 +176,12 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void rStarTreeInsertOneEntryInto1000EntriesMaxChildren004() {
-        insert(smallStarTreeM4);
+        insertRectangle(smallStarTreeM4);
     }
 
     @Benchmark
     public void rStarTreeInsertOneEntryInto1000EntriesMaxChildren010() {
-        insert(smallStarTreeM10);
+        insertRectangle(smallStarTreeM10);
     }
 
     @Benchmark
@@ -179,7 +196,7 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void defaultRTreeInsertOneEntryInto1000EntriesMaxChildren032() {
-        insert(smallDefaultTreeM32);
+        insertRectangle(smallDefaultTreeM32);
     }
 
     @Benchmark
@@ -189,7 +206,7 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void rStarTreeInsertOneEntryInto1000EntriesMaxChildren032() {
-        insert(smallStarTreeM32);
+        insertRectangle(smallStarTreeM32);
     }
 
     @Benchmark
@@ -199,7 +216,7 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void defaultRTreeInsertOneEntryInto1000EntriesMaxChildren128() {
-        insert(smallDefaultTreeM128);
+        insertRectangle(smallDefaultTreeM128);
     }
 
     @Benchmark
@@ -209,7 +226,7 @@ public class BenchmarksRTree {
 
     @Benchmark
     public void rStarTreeInsertOneEntryInto1000EntriesMaxChildren128() {
-        insert(smallStarTreeM128);
+        insertRectangle(smallStarTreeM128);
     }
 
     @Benchmark
@@ -222,21 +239,21 @@ public class BenchmarksRTree {
         deleteAll(starTreeM10);
     }
 
-    private void deleteAll(RTree<Object> tree) {
+    private void deleteAll(RTree<Object, Point> tree) {
         tree.delete(entries.get(1000), true);
     }
 
-    private void search(RTree<Object> tree) {
+    private void search(RTree<Object, Rectangle> tree) {
         // returns 10 results
         tree.search(Geometries.rectangle(500, 500, 630, 630)).subscribe();
     }
 
-    private void searchGreek(RTree<Object> tree) {
+    private void searchGreek(RTree<Object, Point> tree) {
         // should return 22 results
         tree.search(Geometries.rectangle(40, 27.0, 40.5, 27.5)).subscribe();
     }
 
-    private void searchGreekWithBackpressure(RTree<Object> tree) {
+    private void searchGreekWithBackpressure(RTree<Object, Point> tree) {
         // should return 22 results
         tree.search(Geometries.rectangle(40, 27.0, 40.5, 27.5)).subscribe(new Subscriber<Object>() {
 
@@ -262,12 +279,16 @@ public class BenchmarksRTree {
         });
     }
 
-    private void insert(RTree<Object> tree) {
+    private void insertRectangle(RTree<Object, Rectangle> tree) {
         tree.add(new Object(), RTreeTest.random());
     }
 
+    private void insertPoint(RTree<Object, Point> tree) {
+        tree.add(new Object(), Geometries.point(Math.random() * 1000, Math.random() * 1000));
+    }
+
     public static void main(String[] args) {
-        RTree<Object> tree = RTree.create().add(entries1000());
+        RTree<Object, Rectangle> tree = RTree.<Object, Rectangle> create().add(entries1000());
         System.out.println();
         System.out.println(tree.search(Geometries.rectangle(500, 500, 630, 630)).count()
                 .toBlocking().single());

--- a/src/test/java/com/github/davidmoten/rtree/GalleryMain.java
+++ b/src/test/java/com/github/davidmoten/rtree/GalleryMain.java
@@ -5,10 +5,12 @@ import java.util.List;
 
 import rx.Observable;
 
+import com.github.davidmoten.rtree.geometry.Point;
+
 public class GalleryMain {
 
     public static void main(String[] args) {
-        Observable<Entry<Object>> entries = GreekEarthquakes.entries().cache();
+        Observable<Entry<Object, Point>> entries = GreekEarthquakes.entries().cache();
 
         List<Integer> sizes = Arrays.asList(100, 1000, 10000, 1000000);
         List<Integer> maxChildrenValues = Arrays.asList(4, 8, 16, 32, 64, 128);
@@ -16,12 +18,14 @@ public class GalleryMain {
             for (int maxChildren : maxChildrenValues) {
                 if (size > maxChildren) {
                     System.out.println("saving " + size + " m=" + maxChildren);
-                    RTree<Object> tree = RTree.maxChildren(maxChildren).create()
-                            .add(entries.take(size)).last().toBlocking().single();
+                    RTree<Object, Point> tree = RTree.maxChildren(maxChildren)
+                            .<Object, Point> create().add(entries.take(size)).last().toBlocking()
+                            .single();
                     tree.visualize(600, 600).save(
                             "target/greek-" + size + "-" + maxChildren + "-quad.png");
-                    RTree<Object> tree2 = RTree.star().maxChildren(maxChildren).create()
-                            .add(entries.take(size)).last().toBlocking().single();
+                    RTree<Object, Point> tree2 = RTree.star().maxChildren(maxChildren)
+                            .<Object, Point> create().add(entries.take(size)).last().toBlocking()
+                            .single();
                     tree2.visualize(600, 600).save(
                             "target/greek-" + size + "-" + maxChildren + "-star.png");
                 }

--- a/src/test/java/com/github/davidmoten/rtree/GreekEarthquakes.java
+++ b/src/test/java/com/github/davidmoten/rtree/GreekEarthquakes.java
@@ -13,10 +13,11 @@ import rx.functions.Func1;
 import rx.observables.StringObservable;
 
 import com.github.davidmoten.rtree.geometry.Geometries;
+import com.github.davidmoten.rtree.geometry.Point;
 
 public class GreekEarthquakes {
 
-    static Observable<Entry<Object>> entries() {
+    static Observable<Entry<Object, Point>> entries() {
         Observable<String> source = Observable.using(new Func0<InputStream>() {
             @Override
             public InputStream call() {
@@ -43,10 +44,10 @@ public class GreekEarthquakes {
             }
         });
         return StringObservable.split(source, "\n").flatMap(
-                new Func1<String, Observable<Entry<Object>>>() {
+                new Func1<String, Observable<Entry<Object, Point>>>() {
 
                     @Override
-                    public Observable<Entry<Object>> call(String line) {
+                    public Observable<Entry<Object, Point>> call(String line) {
                         if (line.trim().length() > 0) {
                             String[] items = line.split(" ");
                             double lat = Double.parseDouble(items[0]);
@@ -59,7 +60,7 @@ public class GreekEarthquakes {
                 });
     }
 
-    static List<Entry<Object>> entriesList() {
+    static List<Entry<Object, Point>> entriesList() {
         return entries().toList().toBlocking().single();
     }
 }

--- a/src/test/java/com/github/davidmoten/rtree/LeafTest.java
+++ b/src/test/java/com/github/davidmoten/rtree/LeafTest.java
@@ -17,7 +17,7 @@ public class LeafTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testCannotHaveZeroChildren() {
-        new Leaf<Object>(new ArrayList<Entry<Object>>(), context);
+        new Leaf<Object, Rectangle>(new ArrayList<Entry<Object, Rectangle>>(), context);
     }
 
     @Test
@@ -25,7 +25,7 @@ public class LeafTest {
         Rectangle r1 = Geometries.rectangle(0, 1, 3, 5);
         Rectangle r2 = Geometries.rectangle(1, 2, 4, 6);
         @SuppressWarnings("unchecked")
-        Rectangle r = new Leaf<Object>(Arrays.asList(Entry.entry(new Object(), r1),
+        Rectangle r = new Leaf<Object, Rectangle>(Arrays.asList(Entry.entry(new Object(), r1),
                 Entry.entry(new Object(), r2)), context).geometry().mbr();
         assertEquals(r1.add(r2), r);
     }

--- a/src/test/java/com/github/davidmoten/rtree/Main.java
+++ b/src/test/java/com/github/davidmoten/rtree/Main.java
@@ -3,6 +3,7 @@ package com.github.davidmoten.rtree;
 import java.util.List;
 
 import com.github.davidmoten.rtree.geometry.Geometries;
+import com.github.davidmoten.rtree.geometry.Point;
 
 public class Main {
 
@@ -15,11 +16,12 @@ public class Main {
             System.out.println("m=" + m + ", order=" + order);
         }
 
-        List<Entry<Object>> entries = GreekEarthquakes.entriesList();
+        List<Entry<Object, Point>> entries = GreekEarthquakes.entriesList();
         int maxChildren = 10;
-        RTree<Object> tree = RTree.maxChildren(maxChildren).create().add(entries);
-        List<Entry<Object>> list = tree.search(Geometries.rectangle(40, 27.0, 40.5, 27.5)).toList()
-                .toBlocking().single();
+        RTree<Object, Point> tree = RTree.maxChildren(maxChildren).<Object, Point> create()
+                .add(entries);
+        List<Entry<Object, Point>> list = tree.search(Geometries.rectangle(40, 27.0, 40.5, 27.5))
+                .toList().toBlocking().single();
         System.out.println(list.size());
         while (true) {
             // tree.search(Geometries.rectangle(40, 27.0, 40.5,

--- a/src/test/java/com/github/davidmoten/rtree/Utilities.java
+++ b/src/test/java/com/github/davidmoten/rtree/Utilities.java
@@ -7,11 +7,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.github.davidmoten.rtree.geometry.Geometries;
+import com.github.davidmoten.rtree.geometry.Rectangle;
 
 public class Utilities {
 
-    static List<Entry<Object>> entries1000() {
-        List<Entry<Object>> list = new ArrayList<Entry<Object>>();
+    static List<Entry<Object, Rectangle>> entries1000() {
+        List<Entry<Object, Rectangle>> list = new ArrayList<Entry<Object, Rectangle>>();
         BufferedReader br = new BufferedReader(new InputStreamReader(
                 BenchmarksRTree.class.getResourceAsStream("/1000.txt")));
         String line;


### PR DESCRIPTION
adds more type safety

changes the signature of `RTree<T>` to  `RTree<T,S extends Geometry>` to mean that all entries must be entered with a geometry that subclasses `S`.
