### PR TITLE
Fix for race condition where two different threads request 0 

### DIFF
--- a/src/main/java/com/github/davidmoten/rtree/OnSubscribeSearch.java
+++ b/src/main/java/com/github/davidmoten/rtree/OnSubscribeSearch.java
@@ -46,13 +46,14 @@ final class OnSubscribeSearch<T, S extends Geometry> implements OnSubscribe<Entr
         @Override
         public void request(long n) {
             try {
-                if (requested.get() == Long.MAX_VALUE)
-                    // already started with fast path
+                // n>=0 is assured by Subscriber class
+                if (n == 0 || requested.get() == Long.MAX_VALUE)
+                    // none requested or already started with fast path
                     return;
                 else if (n == Long.MAX_VALUE) {
                     // fast path
                     requestAll();
-                } else 
+                } else
                     requestSome(n);
             } catch (RuntimeException e) {
                 subscriber.onError(e);


### PR DESCRIPTION
Two threads can enter the ```OnSubscribeSearch.requestSome``` work loop concurrently if they request 0. If another thread then requests >0 before ```requested.get()``` is called in the loop then a request of 1 could result in two items being emitted.

The fix is to ensure that ```requestSome``` is never called with a request of 0.