### PR TITLE
add support for STR bulk packing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ jdk:
   - openjdk7
   - openjdk6
 
-before_install:
-  - cat /etc/hosts # optionally check the content *before*
-  - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-  - cat /etc/hosts # optionally check the content *after*
+# Workaround for buffer overflow with openjdk6
+# https://github.com/travis-ci/travis-ci/issues/5227
+addons:
+  hosts:
+    - myshorthost
+  hostname: myshorthost
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/src/main/java/com/github/davidmoten/rtree/RTree.java
+++ b/src/main/java/com/github/davidmoten/rtree/RTree.java
@@ -231,7 +231,7 @@ public final class RTree<T, S extends Geometry> {
         /**
          * The factor is used as the fill ratio during bulk loading.
          */
-        public Builder loadingFactor(int factor) {
+        public Builder loadingFactor(double factor) {
             this.loadingFactor = factor;
             return this;
         }

--- a/src/main/java/com/github/davidmoten/rtree/RTree.java
+++ b/src/main/java/com/github/davidmoten/rtree/RTree.java
@@ -332,6 +332,9 @@ public final class RTree<T, S extends Geometry> {
          * Create an RTree by bulk loading, using the STR method.
          * STR: a simple and efficient algorithm for R-tree packing
          * http://ieeexplore.ieee.org/abstract/document/582015/
+         * <p>
+         * Note: this method mutates the input entries, the internal order of the List may be changed.
+         * </p>
          *
          */
         @SuppressWarnings("unchecked")
@@ -399,8 +402,8 @@ public final class RTree<T, S extends Geometry> {
             return packingSTR(nodes, false, size, context);
         }
 
-        private class MidComparator implements Comparator<HasGeometry> {
-            private short dimension; // leave space for multiple dimensions, 0 for x, 1 for y, ...
+        private static final class MidComparator implements Comparator<HasGeometry> {
+            private final short dimension; // leave space for multiple dimensions, 0 for x, 1 for y, ...
 
             public MidComparator(short dim) {
                 dimension = dim;
@@ -415,11 +418,6 @@ public final class RTree<T, S extends Geometry> {
                 Rectangle mbr = o.geometry().mbr();
                 if (dimension == 0) return (mbr.x1() + mbr.x2()) / 2;
                 else return (mbr.y1() + mbr.y2()) / 2;
-            }
-
-            @Override
-            public boolean equals(Object obj) {
-                return obj instanceof MidComparator && dimension == ((MidComparator) obj).dimension;
             }
         }
 

--- a/src/test/java/com/github/davidmoten/rtree/BenchmarksRTree.java
+++ b/src/test/java/com/github/davidmoten/rtree/BenchmarksRTree.java
@@ -155,6 +155,11 @@ public class BenchmarksRTree {
     }
 
     @Benchmark
+    public void bulkLoadingFullRTreeCreation010() {
+        RTree.maxChildren(10).loadingFactor(1.0).<Object, Point> create(entries);
+    }
+
+    @Benchmark
     public void defaultRTreeSearchOfGreekDataPointsMaxChildren004() {
         searchGreek(defaultTreeM4);
     }

--- a/src/test/java/com/github/davidmoten/rtree/BenchmarksRTree.java
+++ b/src/test/java/com/github/davidmoten/rtree/BenchmarksRTree.java
@@ -74,14 +74,17 @@ public class BenchmarksRTree {
     private final RTree<Object, Rectangle> smallStarTreeM128 = RTree.maxChildren(128).star()
             .<Object, Rectangle> create().add(some);
 
+    private final byte[] byteArrayGreek = createFlatBuffersByteArrayGreek();
+
     private final RTree<Object, Point> starTreeM10FlatBuffers = createFlatBuffersGreek();
+
 
     @Benchmark
     public void defaultRTreeInsertOneEntryIntoGreekDataEntriesMaxChildren004() {
         insertPoint(defaultTreeM4);
     }
 
-    private RTree<Object, Point> createFlatBuffersGreek() {
+    private byte[] createFlatBuffersByteArrayGreek() {
         RTree<Object, Point> tree = RTree.maxChildren(10).star().<Object, Point> create()
                 .add(entries);
         final ByteArrayOutputStream os = new ByteArrayOutputStream();
@@ -102,11 +105,53 @@ public class BenchmarksRTree {
         try {
             fbSerializer.write(tree, os);
             os.close();
-            ByteArrayInputStream is = new ByteArrayInputStream(os.toByteArray());
-            return fbSerializer.read(is, os.size(), InternalStructure.SINGLE_ARRAY);
+            return os.toByteArray();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private RTree<Object, Point> createFlatBuffersGreek() {
+        Func1<Object, byte[]> serializer = new Func1<Object, byte[]>() {
+            @Override
+            public byte[] call(Object o) {
+                return new byte[0];
+            }
+        };
+        Func1<byte[], Object> deserializer = new Func1<byte[], Object>() {
+            @Override
+            public Object call(byte[] bytes) {
+                return null;
+            }
+        };
+        Serializer<Object, Point> fbSerializer = SerializerFlatBuffers.create(serializer,
+                deserializer);
+        try {
+            ByteArrayInputStream is = new ByteArrayInputStream(byteArrayGreek);
+            return fbSerializer.read(is, byteArrayGreek.length, InternalStructure.SINGLE_ARRAY);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Benchmark
+    public void defaultRTreeCreation010() {
+        RTree.maxChildren(10).<Object, Point> create().add(entries);
+    }
+
+    @Benchmark
+    public void starRTreeCreation010() {
+        RTree.maxChildren(10).star().<Object, Point> create().add(entries);
+    }
+
+    @Benchmark
+    public void flatBufferRTreeCreation010() {
+        createFlatBuffersGreek();
+    }
+
+    @Benchmark
+    public void bulkLoadingRTreeCreation010() {
+        RTree.maxChildren(10).<Object, Point> create(entries);
     }
 
     @Benchmark

--- a/src/test/java/com/github/davidmoten/rtree/RTreeTest.java
+++ b/src/test/java/com/github/davidmoten/rtree/RTreeTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.github.davidmoten.rtree.internal.EntryDefault;
 import org.junit.Test;
 
 import com.github.davidmoten.guavamini.Lists;
@@ -104,6 +105,40 @@ public class RTreeTest {
     public void testVisualizerWithEmptyTree() {
         RTree<Object, Geometry> tree = RTree.create();
         tree.visualize(600, 600).save("target/tree.png", "PNG");
+    }
+
+    @Test
+    public void testBulkLoadingEmpty() {
+        RTree<Object, Point> tree = RTree.create(new ArrayList<Entry<Object, Point>>());
+        assertTrue(tree.entries().isEmpty().toBlocking().single());
+    }
+
+    @Test
+    public void testBulkLoadingWithOneItemIsNotEmpty() {
+        RTree<Object, Rectangle> tree = RTree.create(Arrays.asList(e(1)));
+        assertFalse(tree.isEmpty());
+    }
+
+    @Test
+    public void testBulkLoadingEntryCount() {
+        List<Entry<Integer, Geometry>> entris = new ArrayList<Entry<Integer, Geometry>>(10000);
+        for (int i = 1; i <= 10000; i++) {
+            Point point = nextPoint();
+            // System.out.println("point(" + point.x() + "," + point.y() +
+            // "),");
+            entris.add(new EntryDefault<Integer, Geometry>(i, point));
+        }
+        RTree<Integer, Geometry> tree = RTree.create(entris);
+        int entrySize = tree.entries().count().toBlocking().single();
+        System.out.println("entry count: " + entrySize);
+        assertEquals(entrySize, entris.size());
+    }
+
+    @Test
+    public void testSearchOnOneItemOnBulkLoadingRTree() {
+        Entry<Object, Rectangle> entry = e(1);
+        RTree<Object, Rectangle> tree = RTree.create(Arrays.asList(entry));
+        assertEquals(Arrays.asList(entry), tree.search(r(1)).toList().toBlocking().single());
     }
 
     @Test
@@ -524,6 +559,9 @@ public class RTreeTest {
 
         RTree<Object, Geometry> tree2 = RTree.star().maxChildren(maxChildren).create().add(entries);
         tree2.visualize(600, 600).save("target/tree2.png");
+
+        RTree<Object, Geometry> tree3 = RTree.maxChildren(maxChildren).create(entries);
+        tree3.visualize(600, 600).save("target/tree3.png");
     }
 
     @Test(expected = RuntimeException.class)
@@ -564,6 +602,10 @@ public class RTreeTest {
         RTree<Object, Point> tree2 = RTree.maxChildren(maxChildren).star().<Object, Point> create()
                 .add(entries);
         tree2.visualize(2000, 2000).save("target/greek2.png");
+
+
+        RTree<Object, Point> tree3 = RTree.maxChildren(maxChildren).create(entries);
+        tree3.visualize(2000, 2000).save("target/greek3.png");
     }
 
     @Test
@@ -703,7 +745,7 @@ public class RTreeTest {
     }
 
     @Test
-    public void testStarTreeReturnsSameAsStandardRTree() {
+    public void testBulkLoadingTreeAndStarTreeReturnsSameAsStandardRTree() {
 
         RTree<Integer, Geometry> tree1 = RTree.create();
         RTree<Integer, Geometry> tree2 = RTree.star().create();
@@ -713,25 +755,33 @@ public class RTreeTest {
                 rectangle(1, 0.252, 50, 69.23), rectangle(13.12, 23.123, 50.45, 80.9),
                 rectangle(10, 10, 50, 50) };
 
+        List<Entry<Integer, Geometry>> entris = new ArrayList<Entry<Integer, Geometry>>(10000);
         for (int i = 1; i <= 10000; i++) {
             Point point = nextPoint();
             // System.out.println("point(" + point.x() + "," + point.y() +
             // "),");
             tree1 = tree1.add(i, point);
             tree2 = tree2.add(i, point);
+            entris.add(new EntryDefault<Integer, Geometry>(i, point));
         }
+        RTree<Integer, Geometry> tree3 = RTree.create(entris);
+
+        // tree2.visualize(2000, 2000).save("target/tree22.png");
+        // tree3.visualize(2000, 2000).save("target/tree33.png");
 
         for (Rectangle r : testRects) {
             Set<Integer> res1 = new HashSet<Integer>(tree1.search(r)
                     .map(RTreeTest.<Integer> toValue()).toList().toBlocking().single());
             Set<Integer> res2 = new HashSet<Integer>(tree2.search(r)
                     .map(RTreeTest.<Integer> toValue()).toList().toBlocking().single());
-            // System.out.println("searchRect= rectangle(" + r.x1() + "," +
-            // r.y1() + "," + r.x2() + "," + r.y2()+ ")");
-            // System.out.println("res1.size=" + res1.size() + ",res2.size=" +
-            // res2.size());
-            // System.out.println("res1=" + res1 + ",res2=" + res2);
+            Set<Integer> res3 = new HashSet<Integer>(tree3.search(r)
+                    .map(RTreeTest.<Integer> toValue()).toList().toBlocking().single());
+             System.out.println("searchRect= rectangle(" + r.x1() + "," +
+             r.y1() + "," + r.x2() + "," + r.y2()+ ")");
+             System.out.println("res1.size=" + res1.size() + ",res2.size=" + res2.size() + ",res3.size=" + res3.size());
+             // System.out.println("res1=" + res1 + ",res2=" + res2 + ",res3=" + res3);
             assertEquals(res1.size(), res2.size());
+            assertEquals(res1.size(), res3.size());
         }
     }
 

--- a/src/test/java/com/github/davidmoten/rtree/RTreeTest.java
+++ b/src/test/java/com/github/davidmoten/rtree/RTreeTest.java
@@ -121,17 +121,17 @@ public class RTreeTest {
 
     @Test
     public void testBulkLoadingEntryCount() {
-        List<Entry<Integer, Geometry>> entris = new ArrayList<Entry<Integer, Geometry>>(10000);
+        List<Entry<Integer, Geometry>> entries = new ArrayList<Entry<Integer, Geometry>>(10000);
         for (int i = 1; i <= 10000; i++) {
             Point point = nextPoint();
             // System.out.println("point(" + point.x() + "," + point.y() +
             // "),");
-            entris.add(new EntryDefault<Integer, Geometry>(i, point));
+            entries.add(new EntryDefault<Integer, Geometry>(i, point));
         }
-        RTree<Integer, Geometry> tree = RTree.create(entris);
+        RTree<Integer, Geometry> tree = RTree.create(entries);
         int entrySize = tree.entries().count().toBlocking().single();
         System.out.println("entry count: " + entrySize);
-        assertEquals(entrySize, entris.size());
+        assertEquals(entrySize, entries.size());
     }
 
     @Test
@@ -755,16 +755,16 @@ public class RTreeTest {
                 rectangle(1, 0.252, 50, 69.23), rectangle(13.12, 23.123, 50.45, 80.9),
                 rectangle(10, 10, 50, 50) };
 
-        List<Entry<Integer, Geometry>> entris = new ArrayList<Entry<Integer, Geometry>>(10000);
+        List<Entry<Integer, Geometry>> entries = new ArrayList<Entry<Integer, Geometry>>(10000);
         for (int i = 1; i <= 10000; i++) {
             Point point = nextPoint();
             // System.out.println("point(" + point.x() + "," + point.y() +
             // "),");
             tree1 = tree1.add(i, point);
             tree2 = tree2.add(i, point);
-            entris.add(new EntryDefault<Integer, Geometry>(i, point));
+            entries.add(new EntryDefault<Integer, Geometry>(i, point));
         }
-        RTree<Integer, Geometry> tree3 = RTree.create(entris);
+        RTree<Integer, Geometry> tree3 = RTree.create(entries);
 
         // tree2.visualize(2000, 2000).save("target/tree22.png");
         // tree3.visualize(2000, 2000).save("target/tree33.png");


### PR DESCRIPTION
For Issue #45 

add support of Rtree creation through STR packing, according to the paper:
[STR: a simple and efficient algorithm for R-tree packing](http://ieeexplore.ieee.org/abstract/document/582015/)

add a recursive function in RTree.Builder and set the default filling factor as 0.7 (1.0 is better for readonly RTree while 0.7 reserves space for insertion).

note that this implementation is only for 2D RTree. 