### PR TITLE
implement PointDouble.hashCode and equals

### DIFF
--- a/src/main/java/com/github/davidmoten/rtree/geometry/internal/PointDouble.java
+++ b/src/main/java/com/github/davidmoten/rtree/geometry/internal/PointDouble.java
@@ -105,4 +105,32 @@ public final class PointDouble implements Point {
         return true;
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+        temp = Double.doubleToLongBits(x);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(y);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        PointDouble other = (PointDouble) obj;
+        if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
+            return false;
+        if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
+            return false;
+        return true;
+    }
+
 }

--- a/src/test/java/com/github/davidmoten/rtree/RTreeTest.java
+++ b/src/test/java/com/github/davidmoten/rtree/RTreeTest.java
@@ -1059,6 +1059,22 @@ public class RTreeTest {
         assertEquals(6, (int) tree.search(rectangle).count().toBlocking().single());
 
     }
+    
+    @Test
+    public void testDeleteIssue81d() {
+         RTree<Object, Point> t = RTree.create();
+         t = t.add(1, Geometries.pointGeographic(123.4d, 23.3d));
+         t = t.delete(1, Geometries.pointGeographic(123.4d, 23.3d));
+         assertEquals(0, t.size());
+     }
+    
+     @Test
+     public void testDeleteIssue81f() {
+         RTree<Object, Point> t = RTree.create();
+         t = t.add(1, Geometries.pointGeographic(123.4f, 23.3f));
+         t = t.delete(1, Geometries.pointGeographic(123.4f, 23.3f));
+         assertEquals(0, t.size());
+     }
 
     private static Func2<Point, Circle, Double> distanceCircleToPoint = new Func2<Point, Circle, Double>() {
         @Override


### PR DESCRIPTION
Discussion in #81 

`PointDouble` did not implement `hashCode` and `equals` properly so deletion from a double `RTree` did not work properly. 