### PR TITLE
Fix #196: honour minChildren when deleting from non-leaf nodes

### DIFF
--- a/src/main/java/com/github/davidmoten/rtree/internal/NonLeafHelper.java
+++ b/src/main/java/com/github/davidmoten/rtree/internal/NonLeafHelper.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import com.github.davidmoten.rtree.Context;
 import com.github.davidmoten.rtree.Entry;
+import com.github.davidmoten.rtree.Leaf;
 import com.github.davidmoten.rtree.Node;
 import com.github.davidmoten.rtree.NonLeaf;
 import com.github.davidmoten.rtree.geometry.Geometry;
@@ -110,12 +111,40 @@ public final class NonLeafHelper {
         else {
             List<Node<T, S>> nodes = Util.remove(children, removeTheseNodes);
             nodes.addAll(addTheseNodes);
-            if (nodes.isEmpty())
-                return new NodeAndEntries<>(Optional.empty(), addTheseEntries,
-                        countDeleted);
-            else {
+            if (nodes.size() < node.context().minChildren()) {
+                // this node has fallen below minChildren so it must be
+                // dissolved: all entries in its remaining children (which may
+                // themselves be non-leaf nodes) are collected and passed up
+                // to be redistributed (re-added) higher up the tree, exactly
+                // as happens for leaves in LeafHelper.delete
+                List<Entry<T, S>> entries = new ArrayList<Entry<T, S>>(addTheseEntries);
+                entries.addAll(getEntries(nodes));
+                return new NodeAndEntries<>(Optional.empty(), entries, countDeleted);
+            } else {
                 NonLeaf<T, S> nd = node.context().factory().createNonLeaf(nodes, node.context());
                 return new NodeAndEntries<>(of(nd), addTheseEntries, countDeleted);
+            }
+        }
+    }
+
+    private static <T, S extends Geometry> List<Entry<T, S>> getEntries(
+            List<? extends Node<T, S>> nodes) {
+        List<Entry<T, S>> list = new ArrayList<Entry<T, S>>();
+        for (Node<T, S> node : nodes) {
+            addEntries(node, list);
+        }
+        return list;
+    }
+
+    private static <T, S extends Geometry> void addEntries(Node<T, S> node,
+            List<Entry<T, S>> list) {
+        if (node instanceof Leaf) {
+            list.addAll(((Leaf<T, S>) node).entries());
+        } else if (node instanceof NonLeaf) {
+            NonLeaf<T, S> n = (NonLeaf<T, S>) node;
+            int count = n.count();
+            for (int i = 0; i < count; i++) {
+                addEntries((Node<T, S>) n.child(i), list);
             }
         }
     }

--- a/src/test/java/com/github/davidmoten/rtree/RTreeTest.java
+++ b/src/test/java/com/github/davidmoten/rtree/RTreeTest.java
@@ -1073,6 +1073,51 @@ public class RTreeTest {
          assertEquals(0, t.size());
      }
 
+    @Test
+    public void testDeleteIssue196() {
+        // non-leaf nodes must dissolve (not just be kept as-is) once their
+        // child count falls below minChildren, cascading up through the tree
+        int maxChildren = 3;
+        int minChildren = 2;
+        RTree<Object, Rectangle> tree = RTree.maxChildren(maxChildren).minChildren(minChildren)
+                .<Object, Rectangle>create();
+        List<Entry<Object, Rectangle>> entries = new ArrayList<Entry<Object, Rectangle>>();
+        for (int i = 1; i <= 30; i++) {
+            entries.add(e(i));
+        }
+        for (Entry<Object, Rectangle> entry : entries) {
+            tree = tree.add(entry);
+        }
+        assertTrue(tree.calculateDepth() > 2);
+        for (int i = 0; i < entries.size() - 1; i++) {
+            tree = tree.delete(entries.get(i));
+            assertFalse(tree.entries().contains(entries.get(i)).toBlocking().single());
+            assertMinChildrenRespected(tree.root(), minChildren);
+        }
+        assertEquals(1, tree.size());
+    }
+
+    private static void assertMinChildrenRespected(Optional<? extends Node<Object, Rectangle>> root,
+            int minChildren) {
+        if (root.isPresent()) {
+            assertMinChildrenRespected(root.get(), minChildren, true);
+        }
+    }
+
+    private static void assertMinChildrenRespected(Node<Object, Rectangle> node, int minChildren,
+            boolean isRoot) {
+        if (node instanceof NonLeaf) {
+            NonLeaf<Object, Rectangle> n = (NonLeaf<Object, Rectangle>) node;
+            if (!isRoot) {
+                assertTrue("non-leaf node has " + n.count() + " children, less than minChildren="
+                        + minChildren, n.count() >= minChildren);
+            }
+            for (int i = 0; i < n.count(); i++) {
+                assertMinChildrenRespected(n.child(i), minChildren, false);
+            }
+        }
+    }
+
     private static Func2<Point, Circle, Double> distanceCircleToPoint = new Func2<Point, Circle, Double>() {
         @Override
         public Double call(Point point, Circle circle) {


### PR DESCRIPTION
## Summary
- `NonLeafHelper.delete` previously only dissolved a non-leaf node when it became completely empty, so a node could survive deletion with fewer than `minChildren` children — violating the R-tree's structural invariant (#196).
- The fix mirrors the existing `LeafHelper.delete` behavior: when a non-leaf's remaining children drop below `minChildren`, the node is dissolved and all entries in its subtree (leaf and non-leaf descendants alike) are collected and bubbled up for re-insertion higher in the tree.
- Added `getEntries`/`addEntries` helpers to recursively collect entries from a node's children during dissolution.

## Test plan
- Added `testDeleteIssue196` to `RTreeTest`, which builds a multi-level tree (`maxChildren=3`, `minChildren=2`), deletes entries one at a time, and after each deletion walks the tree verifying every non-root non-leaf node still has at least `minChildren` children.
- Verified this test fails against the pre-fix code (`non-leaf node has 1 children, less than minChildren=2`) and passes with the fix.
- Full suite: `mvn test` — 312 tests, 0 failures, 0 errors.
