### PR TITLE
Fix LineFloat to store coordinates as float instead of double (#89)

### DIFF
--- a/src/main/java/com/github/davidmoten/rtree/geometry/internal/LineFloat.java
+++ b/src/main/java/com/github/davidmoten/rtree/geometry/internal/LineFloat.java
@@ -17,19 +17,19 @@ import java.util.Optional;
  */
 public final class LineFloat implements Line {
 
-    private final double x1;
-    private final double y1;
-    private final double x2;
-    private final double y2;
+    private final float x1;
+    private final float y1;
+    private final float x2;
+    private final float y2;
 
-    private LineFloat(double x1, double y1, double x2, double y2) {
+    private LineFloat(float x1, float y1, float x2, float y2) {
         this.x1 = x1;
         this.y1 = y1;
         this.x2 = x2;
         this.y2 = y2;
     }
 
-    public static LineFloat create(double x1, double y1, double x2, double y2) {
+    public static LineFloat create(float x1, float y1, float x2, float y2) {
         return new LineFloat(x1, y1, x2, y2);
     }
 

--- a/src/test/java/com/github/davidmoten/rtree/geometry/LineTest.java
+++ b/src/test/java/com/github/davidmoten/rtree/geometry/LineTest.java
@@ -9,6 +9,9 @@ import java.awt.geom.Line2D;
 
 import org.junit.Test;
 
+import com.github.davidmoten.rtree.geometry.internal.LineDouble;
+import com.github.davidmoten.rtree.geometry.internal.LineFloat;
+
 public final class LineTest {
 
     private static final double PRECISION = 0.00001;
@@ -220,6 +223,23 @@ public final class LineTest {
             
             assertTrue(line.intersects(horizontalLine.mbr()));
         }
+    }
+
+    @Test
+    public void testLineFloatStoresCoordinatesAsFloatNotDouble() throws NoSuchFieldException {
+        // https://github.com/davidmoten/rtree/issues/89
+        for (String field : new String[] { "x1", "y1", "x2", "y2" }) {
+            assertEquals(float.class, LineFloat.class.getDeclaredField(field).getType());
+        }
+        for (String field : new String[] { "x1", "y1", "x2", "y2" }) {
+            assertEquals(double.class, LineDouble.class.getDeclaredField(field).getType());
+        }
+    }
+
+    @Test
+    public void testLineFloatIsNotDoublePrecision() {
+        assertFalse(Geometries.line(1f, 2f, 3f, 4f).isDoublePrecision());
+        assertTrue(Geometries.line(1d, 2d, 3d, 4d).isDoublePrecision());
     }
 
 }


### PR DESCRIPTION
## Problem
`LineFloat` was declaring its `x1`, `y1`, `x2`, `y2` fields (and constructor/factory parameters) as `double` instead of `float`, defeating the purpose of having a separate float-precision `Line` implementation alongside `LineDouble`.

Fixes #89

## Changes
- Changed `LineFloat`'s fields, private constructor, and `create()` factory method to use `float` instead of `double` for coordinates ([LineFloat.java](src/main/java/com/github/davidmoten/rtree/geometry/internal/LineFloat.java))
- Added tests verifying:
  - `LineFloat` fields are declared as `float` while `LineDouble` fields remain `double` (via reflection)
  - `Geometries.line(...)` created from float coordinates reports `isDoublePrecision() == false`, and from double coordinates reports `true`

## Test plan
- [x] `mvn test` passes, including new `LineTest` cases
